### PR TITLE
Fix ordering of lat and long when creating point column

### DIFF
--- a/haverhill_311_function/modules/db.py
+++ b/haverhill_311_function/modules/db.py
@@ -21,7 +21,7 @@ def construct_point(context) -> WKBElement:
     latitude = context.get_current_parameters()['latitude']
     longitude = context.get_current_parameters()['longitude']
     return from_shape(
-        shape=Point(latitude, longitude),
+        shape=Point(longitude, latitude),
         srid=NAD_83
     )
 


### PR DESCRIPTION
Realized when plotting the data from the db that the points were showing up somewhere in Antarctica, ended up that lat and long were swapped when storing to db.